### PR TITLE
Modified code to reduce RAM usage in degnorm()

### DIFF
--- a/R/NMF_functions_short.R
+++ b/R/NMF_functions_short.R
@@ -43,6 +43,8 @@ degnorm <- function(read_coverage, counts, iteration=5, loop=100,
                     1 (down-sampling) or 0 (not down-sampling)!")
     if(grid_size %% 1!=0||grid_size<0) {
         stop("Error: grid_size must be a positive integer.")}
+    if(!is.numeric(cores)){
+        stop("Error: cores must be a positive integer.")}
     # filtering out genes with low expressions
     message("Filtering out genes with low read counts (x<5)..")
     n = dim(counts)[2]
@@ -59,9 +61,9 @@ degnorm <- function(read_coverage, counts, iteration=5, loop=100,
     message("Initial degradation normalization without base-line selection...")
     rho = NULL
     i=1
-    rho = foreach(i = seq_len(m),.combine = "rbind",
+    rho = foreach(i = read_coverage,.combine = "rbind",
                     .export = ".ratioSVD") %dopar% {
-                    .ratioSVD(f = read_coverage[[i]])}
+                    .ratioSVD(f = i)}
     stopImplicitCluster()
     stopCluster(cl)
     norm.factor = colSums(counts[apply(rho,1,max) < 0.10,])
@@ -96,13 +98,13 @@ degnorm <- function(read_coverage, counts, iteration=5, loop=100,
         registerDoParallel(cl)
         res = NULL;j=1;m=dim(counts)[1];n=dim(counts)[2]
         if(down_sampling==0){
-            res = foreach(j = seq_len(m), .multicombine = TRUE,
+            res = foreach(j = read_coverage, .multicombine = TRUE,
                 .export = c(".optiNMFCPP",".NMFCPP",".bin_drop")) %dopar%{
-                .optiNMFCPP(read_coverage[[j]], scale, loop, baseline)}
+                .optiNMFCPP(j, scale, loop, baseline)}
         }else if (down_sampling==1){
-            res = foreach(j = seq_len(m), .multicombine = TRUE,
+            res = foreach(j =read_coverage, .multicombine = TRUE,
                 .export = c(".optiNMFCPP_grid",".NMFCPP",".bin_drop")) %dopar%{
-                .optiNMFCPP_grid(read_coverage[[j]], scale, loop, grid_size)}
+                .optiNMFCPP_grid(j, scale, loop, grid_size)}
         }else{
             stop("Error:down_sampling argument should either 0 or 1!")
         }

--- a/R/NMF_functions_short.R
+++ b/R/NMF_functions_short.R
@@ -35,7 +35,7 @@
 #               shape before degradation.
 ################################################################################
 degnorm <- function(read_coverage, counts, iteration=5, loop=100,
-                    down_sampling=1, grid_size=10,cores=1){
+                    down_sampling=1, grid_size=10,cores=1,read_thresh=5,sample_prop=0.50){
     # filtering out genes with low expressions
     if(length(read_coverage)!=nrow(counts)) stop("Error: number of genes from
                     coverage list is inconsistent with the counts matrix!")
@@ -46,9 +46,9 @@ degnorm <- function(read_coverage, counts, iteration=5, loop=100,
     if(!is.numeric(cores)){
         stop("Error: cores must be a positive integer.")}
     # filtering out genes with low expressions
-    message("Filtering out genes with low read counts (x<5)..")
+    message("Filtering out genes with low read counts..")
     n = dim(counts)[2]
-    filter = apply(counts, 1, function(x) length(x[x>5])>=floor(n/2))
+    filter = apply(counts, 1, function(x) length(x[x>read_thresh])>=floor(n*sample_prop))
     counts = counts[filter,];  m = dim(counts)[1]
     read_coverage = read_coverage[which(filter=="TRUE")]
     # Estimating library sizes / scaling factors from SVD

--- a/R/coverage_cal_functions.R
+++ b/R/coverage_cal_functions.R
@@ -23,6 +23,8 @@
 ##   5. User can modify scanBamParam in the R codes below as needed.
 ###############################################################################
 read_coverage_batch=function(bam_file_list,gtf_file,cores=1){
+    if(!is.numeric(cores)){
+    stop("Error: cores must be a positive integer.")}
     i=1; options(warn=-1)
     all_genes=.gtf_parse(gtf_file)
     ##simplify bam file names if path information present in file names

--- a/R/coverage_cal_functions.R
+++ b/R/coverage_cal_functions.R
@@ -24,7 +24,7 @@
 ###############################################################################
 read_coverage_batch=function(bam_file_list,gtf_file,cores=1){
     if(!is.numeric(cores)){
-    stop("Error: cores must be a positive integer.")}
+        stop("Error: cores must be a positive integer.")}
     i=1; options(warn=-1)
     all_genes=.gtf_parse(gtf_file)
     ##simplify bam file names if path information present in file names


### PR DESCRIPTION
Hi again,

The extremely high RAM requirements for large datasets identified in [Issue # 10](https://github.com/jipingw/DegNorm/issues/10) are the result of the foreach statements in degnorm() and .degnorm_baseline() copying the entire dataset to each worker CPU. The foreach statements have been modified to distribute only the single list item from read_coverage being used. 

I have also included a sanity check that the value passed to the cores argument in degnorm() and read_coverage_batch() is numeric. Previously, a string passed to cores would progress all the way to makeCluster, which returns an uninformative error. Accidentally passing a string to cores is an easy mistake to make when e.g., reading in command line arguments on a HPC.

Cheers,
Marc Beer